### PR TITLE
ci: disable auto-triggers for deploy and spacelift workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,16 @@
 name: Deploy with Ansible
 
+# Automatic triggers disabled: the target VM/cluster were destroyed.
+# Re-enable the push/schedule triggers below once infrastructure is provisioned again.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'ingress/**'
-      - 'roles/**'
-  schedule:
-    - cron: '0 */6 * * *'
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'ingress/**'
+  #     - 'roles/**'
+  # schedule:
+  #   - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       tags:

--- a/.github/workflows/spacelift.yaml
+++ b/.github/workflows/spacelift.yaml
@@ -1,9 +1,11 @@
   name: Deploy with Spacelift
+  # Automatic triggers disabled: the target VM/cluster were destroyed.
+  # Re-enable the pull_request trigger below once infrastructure is provisioned again.
   on:
     workflow_dispatch:
-    pull_request:
-      branches: [ 'main' ]
-      types: [opened, synchronize, reopened, closed, labeled, unlabeled]
+    # pull_request:
+    #   branches: [ 'main' ]
+    #   types: [opened, synchronize, reopened, closed, labeled, unlabeled]
 
   jobs:
     infrastructure:


### PR DESCRIPTION
## Summary

The OCI VM and k0s cluster were destroyed, so the workflows that connect to that infrastructure would fail on every run. This disables their automatic triggers while keeping them runnable on demand.

## Changes

- **`deploy.yml`** (Ansible deploy to the VM) — commented out the `push` and `schedule` triggers. The `schedule: '0 */6 * * *'` cron in particular would otherwise keep failing every 6 hours against the now-nonexistent host.
- **`spacelift.yaml`** (Spacelift infra deploy) — commented out the `pull_request` trigger.

Both workflows retain `workflow_dispatch`, so they can still be run manually and re-enabled easily once infrastructure is provisioned again. Each disabled block carries an inline comment explaining why and how to restore it.

## Not changed

`backstage-image.yml` and `helm-chart.yml` only build/push container and Helm artifacts on path-specific pushes and do not touch the destroyed infrastructure, so they were left active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hg89nLCQiuXXtUYUEsupZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg89nLCQiuXXtUYUEsupZn)_