### PR TITLE
fix(deps): update @backstage/plugin-auth-backend to 0.29.2 [security]

### DIFF
--- a/gitops/apps/backstage/src/yarn.lock
+++ b/gitops/apps/backstage/src/yarn.lock
@@ -3375,15 +3375,15 @@ __metadata:
   linkType: hard
 
 "@backstage/plugin-auth-backend@npm:^0.29.0":
-  version: 0.29.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.29.0"
+  version: 0.29.2
+  resolution: "@backstage/plugin-auth-backend@npm:0.29.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
-    "@backstage/plugin-auth-node": "npm:^0.7.1"
-    "@backstage/plugin-catalog-node": "npm:^2.2.1"
+    "@backstage/plugin-auth-node": "npm:^0.7.3"
+    "@backstage/plugin-catalog-node": "npm:^2.2.3"
     "@backstage/types": "npm:^1.2.2"
     "@google-cloud/firestore": "npm:^7.0.0"
     connect-session-knex: "npm:^4.0.0"
@@ -3401,7 +3401,7 @@ __metadata:
     passport: "npm:^0.7.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^5.0.0"
-  checksum: 10c0/8f8e6d05a7ad6efd46daebe66bb6b5b93c96aa92b434d78f2a79eb9802af497f0772a981f32d4a1ba34d57c8c4c60b07c15a72a9fe44944d5f747774a44c079d
+  checksum: 10c0/6940ee61bb051d66285a2f7b15861e5e50d6ba50e93fd98f2517d3ba11a1800178f5f4064526eb9602e51f790137f305c29a94ad3685513a25c7018e18bbca95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Re-lands Renovate PR #56 (`@backstage/plugin-auth-backend` `0.29.0` → `0.29.2`), which became un-mergeable in `yarn.lock` after the other Backstage dependency PRs merged into `main`.

`packages/backend/package.json` already declares `^0.29.0` (from #50), so no manifest change is needed — this refreshes only the lockfile resolution from `0.29.0` to `0.29.2`, pulling the transitively-updated `backend-plugin-api ^1.9.3`, `plugin-auth-node ^0.7.3`, and `plugin-catalog-node ^2.2.3` (already present on `main` from the monorepo minor update).

Picks up **GHSA-38hq-7x33-php4** — unauthenticated OAuth account takeover via `redirect_uri` allowlist bypass (CVSS 4.7).

## Verification

- Regenerated via `yarn up '@backstage/plugin-auth-backend@^0.29.0'` (Yarn 4.4.1); `yarn install` completed successfully, so the lockfile is internally consistent.
- The resulting resolution checksum (`10c0/6940ee61…`) is identical to the one Renovate produced in #56, confirming the resolution matches.
- Diff is scoped to the single `plugin-auth-backend` lock entry (+6/-6).

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hg89nLCQiuXXtUYUEsupZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg89nLCQiuXXtUYUEsupZn)_